### PR TITLE
Add serializer demo/test binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ canonical_json = "0.1.0"
    } 
 ```
 
+## Test suite
+
+Run the projet test suite:
+
+```
+$ cargo test
+```
+
+Run @gibson042's Canonical JSON test suite:
+
+```
+$ git clone git@github.com:gibson042/canonicaljson-spec.git
+$ cd canonicaljson-spec/
+$ ./test.sh ../canonicaljson-rs/demo/target/debug/demo
+```
+
+Some known errors:
+
+- `lone leading surrogate in hex escape`
+- `number out of range`
+- `Non-token input after 896 characters: "\u6} surrogate pair\u2014U+1D306`
+
+
 ## See also
 
 * [python-canonicaljson-rs](https://github.com/mozilla-services/python-canonicaljson-rs/): Python bindings for this crate 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["Mathieu Leplatre <mathieu@mozilla.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+canonical_json = { path = ".." }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 canonical_json = { path = ".." }
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 serde_json = "1.0"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,0 +1,20 @@
+use canonical_json::ser::to_string;
+use serde_json;
+use serde_json::Value;
+
+use std::env;
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    // Open the file in read-only mode with buffer.
+    let file = File::open(&args[1]).unwrap();
+    let reader = BufReader::new(file);
+
+    // Read the JSON contents of the file as an instance of `User`.
+    let v: Value = serde_json::from_reader(reader).unwrap();
+
+    print!("{}", to_string(&v).unwrap());
+}


### PR DESCRIPTION
I could run some tests using @gibson042's test suite. It's great!

```
$ git clone git@github.com:gibson042/canonicaljson-spec.git
$ cd canonicaljson-spec/
$ ./test.sh ../canonicaljson-rs/demo/target/debug/demo
```
[output](https://gist.github.com/leplatrem/58d428dae53603843659226348937aff)

The variation of our implementation is larger than I would have
expected, especially around obviously the hardest thing in the world:
numbers! :D

It may perfectly be because I used serde's default JSON reader, since we were
only interested in serialization here. And some `number out of range` :)

I really wish we would be able to align, but it requires study, to guarantee continuity of our service
in production.

We would have to remain within the behaviour our clients implementation in JavaScript.
Yes, because unfortunately at the time we aligned the serialization
of floats on the server after we discovered qwirks, it was indeed simpler and less risky than
breaking clients!

Let's see first if we have had any published data recently
with floats, and how. Maybe forbid them in our system for the sake of
having a single specification and test suite.