### PR TITLE
Fix #17: Remove `preserve_order` feature in Cargo serde-json dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A Canonical JSON serializer"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = "1"
 regex = "1"
 hex = "0.4"
 thiserror = "2"


### PR DESCRIPTION
Fix #17

I believe this was mistake from local development :/ 
